### PR TITLE
(readme only) Update URLS to discordjs organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # discord.js-docgen
-This is the application that generates the `docs.json` files for [discord.js](https://github.com/hydrabolt/discord.js) and
-[discord.js-commando](https://github.com/Gawdl3y/discord.js-commando). It parses all JSDocs in any given directories, and outputs
+This is the application that generates the `docs.json` files for [discord.js](https://github.com/discordjs/discord.js) and
+[discord.js-commando](https://github.com/discordjs/Commando). It parses all JSDocs in any given directories, and outputs
 a single JSON file with data about all classes, properties, methods, typedefs, etc. It also accepts custom docs files.
 This is handy for documentation websites, so that they can load the data dynamically and display it however they need.


### PR DESCRIPTION
Nothing much to say here as the title pretty much says it all. I just spotted the old URLs were still in the readme when hovering over them.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [X] This PR **only** includes non-code changes, like changes to documentation, README, etc.