### PR TITLE
refactor: allow custom globs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const mainPromises = [null, null];
 // Parse the JSDocs in all source directories
 console.log('Parsing JSDocs in source files...');
 const files = [];
-for(const dir of config.source) files.push(`${dir}/*.js`, `${dir}/**/*.js`);
+for(const glob of config.source) files.push(glob);
 mainPromises[0] = jsdoc2md.getTemplateData({ files, configure: config.jsdoc }).then(data => {
 	console.log(`${data.length} JSDoc items parsed.`);
 	return data;


### PR DESCRIPTION
This is to allow the usage of our current docgen with Typescript files for our [collection](https://github.com/discordjs/collection) module