### PR TITLE
chore(packages): remove unnecessary deps/incorrectly labelled deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
 		"yargs": "^14.0.0"
 	},
 	"devDependencies": {
-		"eslint": "^6.3.0",
-	}
+		"eslint": "^6.3.0"
+	},
 	"engines": {
 		"node": ">=8.0.0"
 	}

--- a/package.json
+++ b/package.json
@@ -37,12 +37,13 @@
 	},
 	"homepage": "https://github.com/hydrabolt/discord.js-docgen",
 	"dependencies": {
-		"eslint": "^6.3.0",
 		"js-yaml": "^3.13.1",
 		"jsdoc-to-markdown": "^5.0.1",
-		"tsubaki": "^1.3.2",
 		"yargs": "^14.0.0"
 	},
+	"devDependencies": {
+		"eslint": "^6.3.0",
+	}
 	"engines": {
 		"node": ">=8.0.0"
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const { promisify } = require('tsubaki');
+const { promisify } = require('util');
 const fs = require('fs');
 const readFile = promisify(fs.readFile);
 const path = require('path');


### PR DESCRIPTION
- Removes `Tsubaki` and uses the native `Util` module as it is unnecessary for a simple `promisify` call
- Moves eslint from `dependencies` to `devDependencies` in `package.json` 